### PR TITLE
Refactor graphQL interface to allow for shallow mocking

### DIFF
--- a/pkg/cmd/sponsors/list/list.go
+++ b/pkg/cmd/sponsors/list/list.go
@@ -13,6 +13,7 @@ import (
 type ListOptions struct {
 	HttpClient func() (*http.Client, error)
 	IO         *iostreams.IOStreams
+	Getter     *SponsorsListGetter
 
 	Username string
 	Sponsors []string
@@ -22,6 +23,7 @@ func NewCmdList(f *cmdutil.Factory, runF func(*ListOptions) error) *cobra.Comman
 	opts := &ListOptions{
 		HttpClient: f.HttpClient,
 		IO:         f.IOStreams,
+		Getter:     NewSponsorsListGetter(getSponsorsList),
 	}
 
 	cmd := &cobra.Command{
@@ -48,7 +50,7 @@ func listRun(opts *ListOptions) error {
 		return fmt.Errorf("could not create http client: %w", err)
 	}
 
-	opts.Sponsors, err = GetSponsorsList(httpClient, "", opts.Username)
+	opts.Sponsors, err = opts.Getter.get(httpClient, "", opts.Username)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/sponsors/list/list_test.go
+++ b/pkg/cmd/sponsors/list/list_test.go
@@ -66,14 +66,9 @@ func Test_listRun(t *testing.T) {
 			opts: &ListOptions{
 				HttpClient: func() (*http.Client, error) {
 					r := &httpmock.Registry{}
-
-					r.Register(
-						httpmock.GraphQL(`query SponsorsList\b`),
-						httpmock.StringResponse(`{"data": {"user": {"sponsors": {"totalCount": 2, "nodes": [{"login": "mona"}, {"login": "lisa"}]}}}}`))
-
 					return &http.Client{Transport: r}, nil
 				},
-
+				Getter:   NewSponsorsListGetter(getterFactory([]string{"mona", "lisa"}, nil)),
 				Username: "octocat",
 				Sponsors: []string{},
 			},

--- a/pkg/cmd/sponsors/list/queries.go
+++ b/pkg/cmd/sponsors/list/queries.go
@@ -23,7 +23,17 @@ type Node struct {
 	Login string `json:"login"`
 }
 
-func GetSponsorsList(httpClient *http.Client, hostname string, username string) ([]string, error) {
+type GetSponsorsList func(*http.Client, string, string) ([]string, error)
+
+type SponsorsListGetter struct {
+	get GetSponsorsList
+}
+
+func NewSponsorsListGetter(getFn GetSponsorsList) *SponsorsListGetter {
+	return &SponsorsListGetter{get: getFn}
+}
+
+func getSponsorsList(httpClient *http.Client, hostname string, username string) ([]string, error) {
 	client := api.NewClientFromHTTP(httpClient)
 	//queryResult, err := querySponsorsViaReflection(client, hostname, username)
 	queryResult, err := querySponsorsViaStringManipulation(client, hostname, username)

--- a/pkg/cmd/sponsors/list/queries_test.go
+++ b/pkg/cmd/sponsors/list/queries_test.go
@@ -16,6 +16,46 @@ func newTestClient(reg *httpmock.Registry) *api.Client {
 	return api.NewClientFromHTTP(client)
 }
 
+func getterFactory(r []string, err error) GetSponsorsList {
+	return func(*http.Client, string, string) ([]string, error) {
+		return r, err
+	}
+}
+
+func TestSponsorsListGetter(t *testing.T) {
+
+	var tests = []struct {
+		name           string
+		get            GetSponsorsList
+		expectedResult []string
+		expectError    bool
+	}{
+		{
+			name:           "hello world",
+			get:            getterFactory([]string{"hello world"}, nil),
+			expectedResult: []string{"hello world"},
+			expectError:    false,
+		},
+		{
+			name:           "error",
+			get:            getterFactory([]string{}, fmt.Errorf("error")),
+			expectedResult: []string{},
+			expectError:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sponsorsListGetter := NewSponsorsListGetter(tt.get)
+			sponsorsList, err := sponsorsListGetter.get(nil, "", "")
+			if err != nil && !tt.expectError {
+				t.Fatalf("unexpected result: %v", err)
+			}
+			assert.Equal(t, tt.expectedResult, sponsorsList)
+		})
+	}
+}
+
 func Test_querySponsors(t *testing.T) {
 	var tests = []struct {
 		name           string


### PR DESCRIPTION
There was an over-testing pattern in the code in that we were testing the functionality of the querying function in both queries_test and list_test.

This was occuring because the current pattern doesn't allow for easy mocking of the getter function and thus necessitated mocking the http response for each function. This refactor introduces a Getter function to the ListOptions interface and provides the factory functions required for both normal execution and testing of the getter.

This approach has simplified Test_listRun in list_test.go by allowing for direct mocking of the getter without requiring mocking of the graphQl response, resulting in a more orthogonal test suite and non-duplicative testing.

<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->
