### PR TITLE
Add better messaging for empty sponsors list

### DIFF
--- a/pkg/cmd/sponsors/list/list.go
+++ b/pkg/cmd/sponsors/list/list.go
@@ -53,12 +53,12 @@ func listRun(opts *ListOptions) error {
 		return err
 	}
 
-	return formatTTYOutput(opts)
+	return formatOutput(opts)
 }
 
-func formatTTYOutput(opts *ListOptions) error {
+func formatOutput(opts *ListOptions) error {
 
-	if len(opts.Sponsors) == 0 {
+	if len(opts.Sponsors) == 0 && opts.IO.IsStdoutTTY() {
 		fmt.Fprintf(opts.IO.Out, "No sponsors found for %s\n", opts.Username)
 		return nil
 	}

--- a/pkg/cmd/sponsors/list/list.go
+++ b/pkg/cmd/sponsors/list/list.go
@@ -58,6 +58,11 @@ func listRun(opts *ListOptions) error {
 
 func formatTTYOutput(opts *ListOptions) error {
 
+	if len(opts.Sponsors) == 0 {
+		fmt.Fprintf(opts.IO.Out, "No sponsors found for %s\n", opts.Username)
+		return nil
+	}
+
 	table := tableprinter.New(opts.IO, tableprinter.WithHeader("SPONSORS"))
 	for _, sponsor := range opts.Sponsors {
 		table.AddField(sponsor)

--- a/pkg/cmd/sponsors/list/list_test.go
+++ b/pkg/cmd/sponsors/list/list_test.go
@@ -103,6 +103,7 @@ func Test_formatTTYOutput(t *testing.T) {
 		{
 			name: "Simple table",
 			opts: &ListOptions{
+				Username: "octocat",
 				Sponsors: []string{"mona", "lisa"},
 			},
 			wants: []string{
@@ -110,6 +111,22 @@ func Test_formatTTYOutput(t *testing.T) {
 				"mona",
 				"lisa",
 			},
+		},
+		{
+			name: "No Sponsors for octocat",
+			opts: &ListOptions{
+				Username: "octocat",
+				Sponsors: []string{},
+			},
+			wants: []string{"No sponsors found for octocat"},
+		},
+		{
+			name: "No Sponsors for monalisa",
+			opts: &ListOptions{
+				Username: "monalisa",
+				Sponsors: []string{},
+			},
+			wants: []string{"No sponsors found for monalisa"},
 		},
 	}
 

--- a/pkg/cmd/sponsors/list/list_test.go
+++ b/pkg/cmd/sponsors/list/list_test.go
@@ -2,7 +2,6 @@ package list
 
 import (
 	"bytes"
-	"fmt"
 	"net/http"
 	"strings"
 	"testing"
@@ -94,11 +93,12 @@ func Test_listRun(t *testing.T) {
 	}
 }
 
-func Test_formatTTYOutput(t *testing.T) {
+func Test_formatOutput(t *testing.T) {
 	tests := []struct {
 		name  string
 		opts  *ListOptions
 		wants []string
+		isTTY bool
 	}{
 		{
 			name: "Simple table",
@@ -110,7 +110,9 @@ func Test_formatTTYOutput(t *testing.T) {
 				"SPONSORS",
 				"mona",
 				"lisa",
+				"",
 			},
+			isTTY: true,
 		},
 		{
 			name: "No Sponsors for octocat",
@@ -118,7 +120,8 @@ func Test_formatTTYOutput(t *testing.T) {
 				Username: "octocat",
 				Sponsors: []string{},
 			},
-			wants: []string{"No sponsors found for octocat"},
+			wants: []string{"No sponsors found for octocat\n"},
+			isTTY: true,
 		},
 		{
 			name: "No Sponsors for monalisa",
@@ -126,20 +129,31 @@ func Test_formatTTYOutput(t *testing.T) {
 				Username: "monalisa",
 				Sponsors: []string{},
 			},
-			wants: []string{"No sponsors found for monalisa"},
+			wants: []string{"No sponsors found for monalisa\n"},
+			isTTY: true,
+		},
+		{
+			name: "No Sponsors for octocat non-TTY",
+			opts: &ListOptions{
+				Username: "octocat",
+				Sponsors: []string{},
+			},
+			wants: []string{},
+			isTTY: false,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ios, _, stdout, _ := iostreams.Test()
-			ios.SetStdoutTTY(true)
+			ios.SetStdoutTTY(tt.isTTY)
 			tt.opts.IO = ios
 
-			err := formatTTYOutput(tt.opts)
+			err := formatOutput(tt.opts)
 			assert.NoError(t, err)
 
-			expected := fmt.Sprintf("%s\n", strings.Join(tt.wants, "\n"))
+			expected := strings.Join(tt.wants, "\n")
+
 			assert.Equal(t, expected, stdout.String())
 		})
 	}


### PR DESCRIPTION
Changed the `formatTTYOutput` function to be `formatOutput` and handle the no sponsors case for both TTY and non-TTY use cases. This covers the [second](https://github.com/orgs/github/projects/14079/views/2?pane=issue&itemId=71297715) and [third](https://github.com/orgs/github/projects/14079/views/2?pane=issue&itemId=71297716) onboarding tasks.

**TTY**
![Screenshot 2024-07-25 at 3 30 55 PM](https://github.com/user-attachments/assets/29368292-9b30-4e8e-9433-256c3ce1c004)

**non-TTY**
![Screenshot 2024-07-26 at 1 46 08 PM](https://github.com/user-attachments/assets/8d8c09d4-367e-4f03-bc42-0c20b593116c)

**To test**
1. Pull down the branch
2. Run `script/build`
3. Run `bin/gh sponsors list jtmcg` (as I have no sponsors)
4. Run `bin/gh sponsors list jtmcg | cat`