### PR TITLE
Add prompting to sponsors list command when no username is provided

### DIFF
--- a/pkg/cmd/sponsors/list/list.go
+++ b/pkg/cmd/sponsors/list/list.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/cli/cli/v2/internal/gh"
 	"github.com/cli/cli/v2/internal/prompter"
 	"github.com/cli/cli/v2/internal/tableprinter"
 	"github.com/cli/cli/v2/pkg/cmdutil"
@@ -12,20 +13,22 @@ import (
 )
 
 type ListOptions struct {
+	Config     func() (gh.Config, error)
+	Getter     *SponsorsListGetter
 	HttpClient func() (*http.Client, error)
 	IO         *iostreams.IOStreams
-	Getter     *SponsorsListGetter
 	Prompter   prompter.Prompter
 
-	Username string
 	Sponsors []string
+	Username string
 }
 
 func NewCmdList(f *cmdutil.Factory, runF func(*ListOptions) error) *cobra.Command {
 	opts := &ListOptions{
+		Config:     f.Config,
+		Getter:     NewSponsorsListGetter(getSponsorsList),
 		HttpClient: f.HttpClient,
 		IO:         f.IOStreams,
-		Getter:     NewSponsorsListGetter(getSponsorsList),
 		Prompter:   f.Prompter,
 	}
 
@@ -36,9 +39,12 @@ func NewCmdList(f *cmdutil.Factory, runF func(*ListOptions) error) *cobra.Comman
 		RunE: func(cmd *cobra.Command, args []string) error {
 
 			if len(args) == 0 {
+				if !opts.IO.CanPrompt() {
+					return fmt.Errorf("Must specify a user")
+				}
 				input, err := opts.Prompter.Input("Which user do you want to target?", "")
 				if err != nil {
-					return fmt.Errorf("could not prompt")
+					return fmt.Errorf("Could not prompt")
 				}
 				opts.Username = input
 			} else {

--- a/pkg/cmd/sponsors/list/list.go
+++ b/pkg/cmd/sponsors/list/list.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/cli/cli/v2/internal/prompter"
 	"github.com/cli/cli/v2/internal/tableprinter"
 	"github.com/cli/cli/v2/pkg/cmdutil"
 	"github.com/cli/cli/v2/pkg/iostreams"
@@ -14,6 +15,7 @@ type ListOptions struct {
 	HttpClient func() (*http.Client, error)
 	IO         *iostreams.IOStreams
 	Getter     *SponsorsListGetter
+	Prompter   prompter.Prompter
 
 	Username string
 	Sponsors []string
@@ -24,14 +26,24 @@ func NewCmdList(f *cmdutil.Factory, runF func(*ListOptions) error) *cobra.Comman
 		HttpClient: f.HttpClient,
 		IO:         f.IOStreams,
 		Getter:     NewSponsorsListGetter(getSponsorsList),
+		Prompter:   f.Prompter,
 	}
 
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "List sponsors for a user",
-		Args:  cobra.ExactArgs(1),
+		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			opts.Username = args[0]
+
+			if len(args) == 0 {
+				input, err := opts.Prompter.Input("Which user do you want to target?", "")
+				if err != nil {
+					return fmt.Errorf("could not prompt")
+				}
+				opts.Username = input
+			} else {
+				opts.Username = args[0]
+			}
 
 			if runF != nil {
 				return runF(opts)


### PR DESCRIPTION
Prompting allows a user to call `gh sponsors list` with no arguments and then enter the username they would like to query via the terminal prompt

![Screenshot 2024-07-26 at 2 26 58 PM](https://github.com/user-attachments/assets/0d149beb-d7a4-4ee2-90bb-19204f816b2f)

**To Test**
1. Pull down this branch
2. Run `script/build`
3. Run `bin/gh sponsors list`
4. When prompted, enter the name of the user you'd like to target