### PR TITLE
Add --json flag to `gh sponsors list <username>` command

### DIFF
--- a/pkg/cmd/sponsors/list/list_test.go
+++ b/pkg/cmd/sponsors/list/list_test.go
@@ -20,7 +20,7 @@ func TestNewCmdList(t *testing.T) {
 		name             string
 		cli              string
 		prompterStubs    func(*prompter.PrompterMock)
-		wants            string
+		wants            ListOptions
 		isPromptDisabled bool
 		tty              bool
 		env              map[string]string
@@ -30,7 +30,7 @@ func TestNewCmdList(t *testing.T) {
 			name:             "happy path",
 			cli:              "octocat",
 			prompterStubs:    func(p *prompter.PrompterMock) {},
-			wants:            "octocat",
+			wants:            ListOptions{Username: "octocat"},
 			isPromptDisabled: false,
 			tty:              true,
 		},
@@ -47,7 +47,7 @@ func TestNewCmdList(t *testing.T) {
 					}
 				}
 			},
-			wants:            "octocat",
+			wants:            ListOptions{Username: "octocat"},
 			isPromptDisabled: false,
 			tty:              true,
 		},
@@ -64,11 +64,17 @@ func TestNewCmdList(t *testing.T) {
 					}
 				}
 			},
-			wants:            "Must specify a user",
 			isPromptDisabled: true,
 			tty:              true,
 			env:              map[string]string{"GH_PROMPT_DISABLED": "true"},
 			wantsErr:         true,
+		},
+		{
+			name:             "with --json flag",
+			cli:              "octocat --json",
+			wants:            ListOptions{Username: "octocat", JSONResponse: true},
+			isPromptDisabled: false,
+			tty:              true,
 		},
 	}
 
@@ -114,7 +120,8 @@ func TestNewCmdList(t *testing.T) {
 			}
 
 			assert.NoError(t, err)
-			assert.Equal(t, tt.wants, gotOpts.Username)
+			assert.Equal(t, tt.wants.Username, gotOpts.Username)
+			assert.Equal(t, tt.wants.JSONResponse, gotOpts.JSONResponse)
 		})
 	}
 }
@@ -199,6 +206,16 @@ func Test_formatOutput(t *testing.T) {
 				Sponsors: []string{},
 			},
 			wants: []string{},
+			isTTY: false,
+		},
+		{
+			name: "When JSONResponse is true",
+			opts: &ListOptions{
+				Username:     "octocat",
+				Sponsors:     []string{"mona", "lisa"},
+				JSONResponse: true,
+			},
+			wants: []string{"{\"sponsors\":[\"mona\",\"lisa\"]}"},
 			isTTY: false,
 		},
 	}


### PR DESCRIPTION
This allows machine readable, json formating of the output flags

![Screenshot 2024-07-29 at 4 23 44 PM](https://github.com/user-attachments/assets/b6ff22bd-91d8-4b4c-9e72-95279417ca80)

**How to test**
1. Pull down the version
2. Run `script/build`
3. Run `bin/gh sponsors list onsi --json`. It could be helpful to pipe this into `jq` for formating
